### PR TITLE
Rebased embassy-time-driver branch over lastest release

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -37,7 +37,8 @@ version = "0.3"
 optional = true
 
 [dev-dependencies]
-embassy-executor = { version = "0.6.2", features = ["arch-cortex-m", "executor-thread", "task-arena-size-64"] }
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "task-arena-size-64", "nightly"] }
+embassy-time = "0.4.0"
 rtic = { version = "2.1.1", features = ["thumbv6-backend"] }
 rtic-monotonics = { version = "1.3.0", features = ["cortex-m-systick", "systick-10khz"] }
 fugit = "0.3.6"
@@ -68,7 +69,7 @@ express = []
 dma = ["atsamd-hal/dma"]
 max-channels = ["dma", "atsamd-hal/max-channels"]
 # Enable async support from atsamd-hal
-async = ["atsamd-hal/async"]
+async = ["atsamd-hal/async","atsamd-hal/embassy-time-driver"]
 # Enable pins for the adalogger SD card reader
 adalogger = []
 # Enable pins for Feather with WINC1500 wifi
@@ -161,6 +162,10 @@ required-features = ["dma", "async"]
 
 [[example]]
 name = "async_timer"
+required-features = ["async"]
+
+[[example]]
+name = "embassy_timer"
 required-features = ["async"]
 
 [[example]]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -37,7 +37,7 @@ version = "0.3"
 optional = true
 
 [dev-dependencies]
-embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "task-arena-size-64", "nightly"] }
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "task-arena-size-256", "nightly"] }
 embassy-time = "0.4.0"
 rtic = { version = "2.1.1", features = ["thumbv6-backend"] }
 rtic-monotonics = { version = "1.3.0", features = ["cortex-m-systick", "systick-10khz"] }

--- a/boards/feather_m0/examples/embassy_timer.rs
+++ b/boards/feather_m0/examples/embassy_timer.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+
+#[no_mangle]
+pub static RTIC_ASYNC_MAX_LOGICAL_PRIO: u8 = 240;
+// This is required because we are not using RTIC as a runtime.
+// DISCUSSION: https://github.com/rtic-rs/rtic/issues/956#issuecomment-2426930973
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::{hal, pac, pin_alias};
+use feather_m0 as bsp;
+
+use hal::{
+    clock::{ClockGenId, ClockSource, GenericClockController},
+    ehal::digital::StatefulOutputPin,
+    rtc::time_driver::time_driver_init,
+};
+
+use embassy_time::Timer;
+
+
+#[embassy_executor::main]
+async fn main(_s: embassy_executor::Spawner) {
+    let mut peripherals = pac::Peripherals::take().unwrap();
+    let _core = pac::CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.gclk,
+        &mut peripherals.pm,
+        &mut peripherals.sysctrl,
+        &mut peripherals.nvmctrl,
+    );
+    let pins = bsp::Pins::new(peripherals.port);
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+
+    let timer_clock = clocks.configure_gclk_divider_and_source(ClockGenId::Gclk2, 1, ClockSource::Xosc32k, false).unwrap();
+    clocks.configure_standby(ClockGenId::Gclk2, true);
+    let _rtc_clock = clocks.rtc(&timer_clock).unwrap();
+    time_driver_init(peripherals.rtc, &_s); // This calls Mono::start(), makes embassy-time stuff work.
+
+    loop {
+        red_led.toggle().unwrap();
+        Timer::after_secs(1).await;
+    }
+}

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -60,6 +60,8 @@ void = {version = "1.0", default-features = false}
 #===============================================================================
 
 defmt = { version = "0.3.8", optional = true}
+#embassy-executor = {version = "0.6.2", features = [ "nightly" ], optional = true}
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "task-arena-size-64", "nightly"], optional = true }
 embassy-sync = {version = "0.6.0", optional = true}
 embedded-hal-async = {version = "1.0.0", optional = true}
 embedded-io-async = {version = "0.6.1", optional = true}
@@ -70,6 +72,9 @@ mcan-core = {version = "0.2", optional = true}
 rtic-monotonic = {version = "1.0", optional = true}
 usb-device = {version = "0.3.2", optional = true}
 rtic-time = {version = "2.0", optional = true}
+embassy-time-driver = { version = "0.2.0", features = [ "tick-hz-32_768" ], optional = true}
+embassy-time-queue-utils = { version = "0.1.0", optional = true }
+embassy-futures = { version = "0.1.1", optional = true }
 
 #===============================================================================
 # PACs
@@ -198,6 +203,14 @@ async = [
     "futures",
     "portable-atomic"
 ]
+embassy-time-driver = [
+  "async",
+  "rtic",
+  "dep:embassy-executor",
+  "dep:embassy-time-driver",
+  "dep:embassy-time-queue-utils",
+  "dep:embassy-futures",
+]
 
 #===============================================================================
 # Implementation-details
@@ -210,3 +223,4 @@ async = [
 # The `device` feature tells the HAL that a device has been selected from the
 # feature list. It exists mostly to provide better error messages.
 device = []
+

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -60,8 +60,7 @@ void = {version = "1.0", default-features = false}
 #===============================================================================
 
 defmt = { version = "0.3.8", optional = true}
-#embassy-executor = {version = "0.6.2", features = [ "nightly" ], optional = true}
-embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "task-arena-size-64", "nightly"], optional = true }
+embassy-executor = { version = "0.7.0", features = ["nightly"], default-features = false, optional = true }
 embassy-sync = {version = "0.6.0", optional = true}
 embedded-hal-async = {version = "1.0.0", optional = true}
 embedded-io-async = {version = "0.6.1", optional = true}

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(impl_trait_in_assoc_type)]
 
 use embedded_hal_02 as ehal_02;
 pub use embedded_hal_1 as ehal;

--- a/hal/src/rtc/mod.rs
+++ b/hal/src/rtc/mod.rs
@@ -20,6 +20,10 @@ mod modes;
 #[cfg(feature = "rtic")]
 pub mod rtic;
 
+#[cfg(feature = "rtic")]
+#[cfg(feature = "embassy-time-driver")]
+pub mod time_driver;
+
 // SAMx5x imports
 #[hal_cfg("rtc-d5x")]
 use crate::pac::{

--- a/hal/src/rtc/time_driver.rs
+++ b/hal/src/rtc/time_driver.rs
@@ -1,0 +1,117 @@
+//! Embassy timer driver.
+#![allow(unused_imports)]
+
+use core::cell::{Cell, RefCell};
+
+use critical_section::CriticalSection;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::signal::Signal;
+
+use embassy_time_driver::Driver;
+use embassy_time_queue_utils::Queue;
+use embassy_futures::select::{select,Either};
+use embassy_executor::Spawner;
+
+use fugit::{Instant,Duration,ExtU64};
+use crate::{rtc_monotonic,rtc::rtic::rtc_clock};
+use crate::rtic_time::Monotonic;
+
+rtc_monotonic!(Mono, rtc_clock::Clock32k);
+
+type AlarmState = u64;
+
+struct TimerDriver {
+    alarm: Signal<CriticalSectionRawMutex, AlarmState>,
+    queue: Mutex<CriticalSectionRawMutex, RefCell<Queue>>,
+}
+
+embassy_time_driver::time_driver_impl!(static DRIVER: TimerDriver = TimerDriver{
+    alarm:  Signal::new(),
+    queue: Mutex::new(RefCell::new(Queue::new()))
+});
+
+
+impl Driver for TimerDriver {
+    fn now(&self) -> u64 {
+        Mono::now().ticks()
+    }
+    fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(next) {
+                    next = queue.next_expiration(self.now());
+                }
+            }
+        })
+    }
+}
+
+#[embassy_executor::task]
+async fn alarm_watcher_task() {
+    let mut next_alarm : Option<AlarmState> = None;
+
+    loop {
+        if DRIVER.alarm.signaled() {
+            next_alarm = DRIVER.alarm.try_take();
+        }
+
+        // wait until the alarm time, OR until the alarm signals that it was changed.
+        match next_alarm {
+            Some(n) => {
+                let mut next_instant : fugit::Instant<u64,1,32768> = fugit::Instant::<u64,1,32768>::from_ticks(n);
+
+                if n == u64::MAX { // Instant doesnt like to wait until u64::MAX, it seems to cause an overflow internally.
+                    next_instant = Mono::now() + 876000u64.hours(); // 100 years
+                } 
+
+                match select(Mono::delay_until(next_instant), DRIVER.alarm.wait()).await {
+                    Either::First(_) => {
+                        DRIVER.trigger_alarm();
+                    },
+                    Either::Second(new_alarm) => {
+                        next_alarm = Some(new_alarm);
+                    }
+                };
+            },
+            None => {
+                // Wait for a new alarm
+                next_alarm = Some(DRIVER.alarm.wait().await);
+            },
+        };
+    }
+}
+
+impl TimerDriver {
+    fn set_alarm(&self, timestamp: u64) -> bool {
+        self.alarm.signal(timestamp); // triggers a new alarm
+        let now = self.now();
+
+        if timestamp <= now {
+            // If alarm timestamp has passed the alarm will not fire.
+            // Disarm the alarm and return `false` to indicate that.
+            self.alarm.signal(u64::MAX);
+            false
+        } else {
+            true
+        }
+    }
+
+    fn trigger_alarm(&self) {
+        critical_section::with(|cs| {
+            let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+            while !self.set_alarm(next) {
+                next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+            }
+        })
+    }
+}
+
+/// safety: must be called exactly once at bootup
+pub fn time_driver_init(rtc: crate::pac::Rtc, spawner: &embassy_executor::Spawner) {
+    DRIVER.alarm.signal(u64::MAX);
+    Mono::start(rtc);
+    spawner.spawn(alarm_watcher_task()).unwrap();
+}


### PR DESCRIPTION
# Summary
A slightly hacky `embassy-time-driver` for D21 - it works on my machine, and on a SAMD21G18A with external 32K crystal.
I wrote this up so that I could make use of the `embassy_time::{Ticker,Timer}` API, as it is portable across different hardware platforms.

Heavy inspiration was taken from [the RP2040 time_driver here](https://github.com/embassy-rs/embassy/blob/92326f10b5be1d6fdc6bd414eb0656e3890bd825/embassy-rp/src/time_driver.rs) and [the std time_driver here](https://github.com/embassy-rs/embassy/blob/92326f10b5be1d6fdc6bd414eb0656e3890bd825/embassy-time/src/driver_std.rs). 

# Design overview
The `TimerDriver` struct only has two members - `alarm : Signal`, and `queue : embassy_time_queue_utils::Queue`.
 - `alarm` typically stores the time for which we want an 'RTC interrupt' to be generated. 
 - `queue` stores the list of `Waiter`s that are yet to be woken. This is very similar to the other `time_driver` implementations, please refer to the links above.

When items are added to the queue, such as resulting from a `Timer::after_millis(100).await` call, the `alarm` signal is updated with the next time to be woken. 

Drawing inspiration from the `std` [time driver implementation](https://github.com/embassy-rs/embassy/blob/main/embassy-time/src/driver_std.rs), I've created a sort of 'background alarm task', which is responsible for:
 1. Watching for a new `alarm` time to be set, using `Signal::wait()`
 2. Waiting until that alarm time, using `Mono::delay_until()` from the new RTC Monotonic code.
 3. If the alarm time has elapsed, the `trigger_alarm()` function is called. This will wake up and remove items from the queue. In doing so, a new `alarm` time is set.
 4. If the alarm time **has not** elapsed, but the `alarm` signal was raised, then start again using this new alarm time.

# Open questions and notes
1. Is this the right approach? Or should `TimeDriver` be implemented elsewhere, such as inside of the `RtcBackend` directly? (I think so, but I wasn't sure how to approach that when I started this version :) )

2. Is it ergonomic to pass an embassy spawner to `time_driver_init()`? More broadly, is there a way to do this without needing an embassy task (`alarm_watcher_task`)?
 
3. Does the treatment of critical sections (for queue modifications), and the alarm polling logic inside of `alarm_watcher_task`, look correct? 

# Caveats 
1. This approach is 'functional' for code that doesn't enter low-power states, but as soon as the embassy executor is stopped (and `alarm_watcher_task` stops as a result), this will stop working. Most (if not all) `embassy_time_driver::Driver` implementations use proper RTC interrupts, and the proper 'alarm' functionality of the on-chip RTC peripheral, to ensure proper time-keeping even during sleep. 
